### PR TITLE
Fix #73: Allow insecure requests for drand dist_key

### DIFF
--- a/net/listener_grpc.go
+++ b/net/listener_grpc.go
@@ -72,6 +72,7 @@ func NewTCPGrpcListener(addr string, s Service, opts ...grpc.ServerOption) Liste
 	}
 	drand.RegisterRandomnessServer(g.grpcServer, g.Service)
 	drand.RegisterBeaconServer(g.grpcServer, g.Service)
+	drand.RegisterInfoServer(grpcServer, s)
 	dkg.RegisterDkgServer(g.grpcServer, g.Service)
 	return g
 }
@@ -209,7 +210,7 @@ type ControlListener struct {
 func NewTCPGrpcControlListener(s control.ControlServer, port string) ControlListener {
 	lis, err := net.Listen("tcp", fmt.Sprintf("%s:%s", "localhost", port))
 	if err != nil {
-		slog.Fatal("Failed to listen")
+		slog.Fatal("Failed to listen:", err)
 		return ControlListener{}
 	}
 	grpcServer := grpc.NewServer()

--- a/test/test.go
+++ b/test/test.go
@@ -78,12 +78,14 @@ func GenerateIDs(n int) []*key.Pair {
 	return keys
 }
 
+// Generates n insecure identities
 func BatchIdentities(n int) ([]*key.Pair, *key.Group) {
 	privs := GenerateIDs(n)
 	group := key.NewGroup(ListFromPrivates(privs), key.DefaultThreshold(n))
 	return privs, group
 }
 
+// Generates n secure (TLS) identities
 func BatchTLSIdentities(n int) ([]*key.Pair, *key.Group) {
 	pairs, group := BatchIdentities(n)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
Fix for #73. I also added a test in main_test.go for ensuring insecure requests for dist_key continue to work.

Test output:
```
$ go test ./...
ok  	github.com/dedis/drand	1.916s
ok  	github.com/dedis/drand/beacon	(cached)
ok  	github.com/dedis/drand/core	(cached)
ok  	github.com/dedis/drand/dkg	(cached)
ok  	github.com/dedis/drand/ecies	(cached)
ok  	github.com/dedis/drand/fs	(cached)
ok  	github.com/dedis/drand/key	(cached)
ok  	github.com/dedis/drand/net	(cached)
?   	github.com/dedis/drand/protobuf/control	[no test files]
?   	github.com/dedis/drand/protobuf/crypto	[no test files]
?   	github.com/dedis/drand/protobuf/crypto/share	[no test files]
?   	github.com/dedis/drand/protobuf/crypto/share/vss	[no test files]
?   	github.com/dedis/drand/protobuf/dkg	[no test files]
?   	github.com/dedis/drand/protobuf/drand	[no test files]
?   	github.com/dedis/drand/test	[no test files]
```