### PR TITLE
Fix issue #79

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,22 @@ The output will have the following JSON format :
 }
 ```
 
+## Using HTTP endpoints
+
+Sometimes you may want get the distributed key or public randomness by issuing a GET to a HTTP endpoint instead of using
+a gRPC client.
+
+To curl the distributed key, you can use
+```bash
+curl <address>/info/dist_key
+```
+
+Similarly, to get the latest round of randomness from the drand beacon, you can use
+```bash
+curl <address>/public
+```
+
+
 ## Learn More About The Crypto Magic Behind Drand
 
 Drand relies on the following cryptographic constructions:

--- a/net/listener_grpc.go
+++ b/net/listener_grpc.go
@@ -52,6 +52,9 @@ func NewTCPGrpcListener(addr string, s Service, opts ...grpc.ServerOption) Liste
 	if err := drand.RegisterRandomnessHandlerClient(ctx, gwMux, proxyClient); err != nil {
 		panic(err)
 	}
+	if err = drand.RegisterInfoHandlerClient(context.Background(), gwMux, proxyClient); err != nil {
+		panic(err)
+	}
 	restRouter := http.NewServeMux()
 	newHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -72,7 +75,7 @@ func NewTCPGrpcListener(addr string, s Service, opts ...grpc.ServerOption) Liste
 	}
 	drand.RegisterRandomnessServer(g.grpcServer, g.Service)
 	drand.RegisterBeaconServer(g.grpcServer, g.Service)
-	drand.RegisterInfoServer(grpcServer, s)
+	drand.RegisterInfoServer(g.grpcServer, g.Service)
 	dkg.RegisterDkgServer(g.grpcServer, g.Service)
 	return g
 }


### PR DESCRIPTION
Ensures that insecure mode also has an http endpoint for retrieving a distributed key. Also adds brief documentation about how to use the drand beacon's http endpoints.