### PR TITLE
Fix remaining test bug in #73 and some cleanup from PR #79

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -322,17 +322,15 @@ func TestClientInsecure(t *testing.T) {
 	require.True(t, strings.Contains(string(out), keyStr))
 	require.NoError(t, err)
 
-	// TODO: There is an issue when `drand control share` is run with a custom port. It returns the wrong secret value.
-	// Commented out test in meantime.
-	//cmd = exec.Command("drand", "control", "--port", ctrlPort, "share")
-	//out, err = cmd.CombinedOutput()
-	//if err != nil {
-	//	t.Fatalf("could not run the command : %s", err.Error())
-	//}
-	//fmt.Println(out)
-	//expectedOutput := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE="
-	//require.True(t, strings.Contains(string(out), expectedOutput))
-	//require.NoError(t, err)
+	cmd = exec.Command("drand", "control", "share", "--port", ctrlPort)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("could not run the command : %s", err.Error())
+	}
+	fmt.Println(out)
+	expectedOutput := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE="
+	require.True(t, strings.Contains(string(out), expectedOutput))
+	require.NoError(t, err)
 }
 
 func TestClientTLS(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -327,7 +327,6 @@ func TestClientInsecure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not run the command : %s", err.Error())
 	}
-	fmt.Println(out)
 	expectedOutput := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE="
 	require.True(t, strings.Contains(string(out), expectedOutput))
 	require.NoError(t, err)

--- a/net/listener_grpc.go
+++ b/net/listener_grpc.go
@@ -52,7 +52,7 @@ func NewTCPGrpcListener(addr string, s Service, opts ...grpc.ServerOption) Liste
 	if err := drand.RegisterRandomnessHandlerClient(ctx, gwMux, proxyClient); err != nil {
 		panic(err)
 	}
-	if err = drand.RegisterInfoHandlerClient(context.Background(), gwMux, proxyClient); err != nil {
+	if err = drand.RegisterInfoHandlerClient(ctx, gwMux, proxyClient); err != nil {
 		panic(err)
 	}
 	restRouter := http.NewServeMux()


### PR DESCRIPTION
Hi there! I figured out the remaining test bug in #73. I was being dumb and invoking 
```
drand control --port <ctrlPort> share
```
instead of the correct invocation,
```
drand control share --port <ctrlPort>
```
Additionally, I cleaned up some additional lines of code for consistency.
Let me know if you want me to split the test fix and the cleanup into two separate PRs!