### PR TITLE
Fixes #87

### DIFF
--- a/control.go
+++ b/control.go
@@ -18,8 +18,10 @@ func shareCmd(c *cli.Context) error {
 	if !c.Args().Present() {
 		slog.Fatal("drand: needs at least one group.toml file argument")
 	}
+	testEmptyGroup(c.Args().First())
 
 	if c.IsSet(oldGroupFlag.Name) {
+		testEmptyGroup(c.String(oldGroupFlag.Name))
 		slog.Info("drand: old group file given for resharing protocol")
 		return initReshare(c)
 	}
@@ -82,10 +84,6 @@ func initReshare(c *cli.Context) error {
 	}
 	if oldGroupPath == "" {
 		slog.Print("drand: old group path not specified. Using daemon's own group if possible.")
-	}
-
-	if c.NArg() < 1 {
-		slog.Fatalf("drand: need new group given as arguments to reshare")
 	}
 	newGroupPath = c.Args().First()
 

--- a/daemon.go
+++ b/daemon.go
@@ -52,3 +52,15 @@ func stopDaemon(c *cli.Context) error {
 	// XXX TODO
 	panic("not implemented yet")
 }
+
+func stopCmd(c *cli.Context) error {
+	conf := contextToConfig(c)
+	fs := key.NewFileStore(conf.ConfigFolder())
+	var drand *core.Drand
+	drand, err := core.LoadDrand(fs, conf)
+	if err != nil {
+		slog.Fatal(err)
+	}
+	drand.Stop()
+	return nil
+}

--- a/daemon.go
+++ b/daemon.go
@@ -49,18 +49,6 @@ func startCmd(c *cli.Context) error {
 }
 
 func stopDaemon(c *cli.Context) error {
-	// XXX TODO
+	// TODO
 	panic("not implemented yet")
-}
-
-func stopCmd(c *cli.Context) error {
-	conf := contextToConfig(c)
-	fs := key.NewFileStore(conf.ConfigFolder())
-	var drand *core.Drand
-	drand, err := core.LoadDrand(fs, conf)
-	if err != nil {
-		slog.Fatal(err)
-	}
-	drand.Stop()
-	return nil
 }

--- a/main.go
+++ b/main.go
@@ -374,18 +374,6 @@ func testWindows(c *cli.Context) {
 	}
 }
 
-func stopCmd(c *cli.Context) error {
-	conf := contextToConfig(c)
-	fs := key.NewFileStore(conf.ConfigFolder())
-	var drand *core.Drand
-	drand, err := core.LoadDrand(fs, conf)
-	if err != nil {
-		slog.Fatal(err)
-	}
-	drand.Stop()
-	return nil
-}
-
 func keygenCmd(c *cli.Context) error {
 	args := c.Args()
 	if !args.Present() {

--- a/main.go
+++ b/main.go
@@ -145,7 +145,7 @@ func main() {
 			Usage: "Stop the drand daemon.\n",
 			Action: func(c *cli.Context) error {
 				banner()
-				return stopCmd(c)
+				return stopDaemon(c)
 			},
 		},
 		cli.Command{

--- a/main.go
+++ b/main.go
@@ -486,10 +486,10 @@ func toArray(flags ...cli.Flag) []cli.Flag {
 func getGroup(c *cli.Context) *key.Group {
 	g := &key.Group{}
 	groupPath := c.Args().First()
+	testEmptyGroup(groupPath)
 	if err := key.Load(groupPath, g); err != nil {
 		slog.Fatalf("drand: error loading group file: %s", err)
 	}
-	testEmptyGroup(groupPath)
 	slog.Infof("group file loaded with %d participants", g.Len())
 	return g
 }

--- a/main_test.go
+++ b/main_test.go
@@ -163,12 +163,6 @@ func TestStartAndStop(t *testing.T) {
 	if e, ok := err.(*exec.ExitError); ok && e.Success() {
 		t.Fatal(err)
 	}
-	cmd = exec.Command("drand", "-c", tmpPath, "stop")
-	cmd.Env = append(os.Environ(), varEnv+"=1")
-	err = cmd.Run()
-	if e, ok := err.(*exec.ExitError); ok && e.Success() {
-		t.Fatal(err)
-	}
 }
 
 func TestStartBeacon(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -133,6 +133,18 @@ func TestGroup(t *testing.T) {
 	out, err = cmd.CombinedOutput()
 	fmt.Println(string(out))
 	require.Error(t, err)
+
+	//test reject empty group file
+	emptyGroupPath := path.Join(tmpPath, "empty.toml")
+	emptyFile, err := os.Create(emptyGroupPath)
+	if err != nil {
+		slog.Fatal(err)
+	}
+	defer emptyFile.Close()
+	cmd = exec.Command("drand", "--folder", tmpPath, "group", "--group", emptyGroupPath, names[0])
+	out, err = cmd.CombinedOutput()
+	fmt.Println(string(out))
+	require.Error(t, err)
 }
 
 func TestStartAndStop(t *testing.T) {


### PR DESCRIPTION
- Add test to reject empty group file as argument.
Enhancement: change error message when unsuccessfully loading a groupfile to give more info about what went wrong (corrupted groupfile, wrong path, ..)