### PR TITLE
Add entropy package for incorporating custom sources of randomness

### DIFF
--- a/core/drand_public.go
+++ b/core/drand_public.go
@@ -128,7 +128,7 @@ func (d *Drand) Private(c context.Context, priv *drand.PrivateRandRequest) (*dra
 	if err := clientKey.UnmarshalBinary(msg); err != nil {
 		return nil, errors.New("invalid client key")
 	}
-	randomness, err := entropy.GetRandom(32)
+	randomness, err := entropy.GetRandom(nil, 32)
 	if err != nil {
 		return nil, fmt.Errorf("error gathering randomness: %s", err)
 	} else if len(randomness) != 32 {

--- a/ecies/ecies.go
+++ b/ecies/ecies.go
@@ -3,12 +3,11 @@ package ecies
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/rand"
 	"crypto/sha256"
 	"errors"
 	"hash"
-	"io"
 
+	"github.com/dedis/drand/entropy"
 	"github.com/dedis/drand/protobuf/crypto"
 	"github.com/dedis/drand/protobuf/drand"
 	"go.dedis.ch/kyber/v3"
@@ -55,8 +54,8 @@ func Encrypt(g kyber.Group, fn func() hash.Hash, public kyber.Point, msg []byte)
 
 	// even though optional for this mode of ECIES, it _should_ not hurt if we
 	// add it.
-	nonce := make([]byte, 12)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+	nonce, err := entropy.GetRandom(12)
+	if err != nil {
 		return nil, err
 	}
 
@@ -103,10 +102,12 @@ func Decrypt(g kyber.Group, fn func() hash.Hash, priv kyber.Scalar, o *drand.ECI
 
 	// even though optional for this mode of ECIES, it _should_ not hurt if we
 	// add it.
-	nonce := make([]byte, 12)
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
-	}
+
+	// This nonce was never used in the original code; shall we omit generating it?
+	//nonce, err := entropy.GetRandom(12)
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	block, err := aes.NewCipher(key)
 	if err != nil {

--- a/ecies/ecies.go
+++ b/ecies/ecies.go
@@ -54,7 +54,7 @@ func Encrypt(g kyber.Group, fn func() hash.Hash, public kyber.Point, msg []byte)
 
 	// even though optional for this mode of ECIES, it _should_ not hurt if we
 	// add it.
-	nonce, err := entropy.GetRandom(12)
+	nonce, err := entropy.GetRandom(nil, 12)
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +102,6 @@ func Decrypt(g kyber.Group, fn func() hash.Hash, priv kyber.Scalar, o *drand.ECI
 
 	// even though optional for this mode of ECIES, it _should_ not hurt if we
 	// add it.
-
-	// This nonce was never used in the original code; shall we omit generating it?
-	//nonce, err := entropy.GetRandom(12)
-	//if err != nil {
-	//	return nil, err
-	//}
 
 	block, err := aes.NewCipher(key)
 	if err != nil {

--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -1,0 +1,39 @@
+package entropy
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+func GetRandom(len uint32) ([]byte, error) {
+	random := make([]byte, len)
+	err := customEntropy(random)
+	if err != nil {
+		// If customEntropy provides an error, fallback to go crypto/rand generator.
+		_, err := rand.Read(random)
+		return random, err
+	}
+	return random, nil
+}
+
+func customEntropy(random []byte) (error) {
+	// Stub: return error because no custom entropy has been implemented yet.
+	return fmt.Errorf("no custom source of entropy has been implemented yet")
+
+	/* An example of providing randomness from an fake http endpoint:
+
+	url := fmt.Sprintf("https://randomness-source.com/entropy?bytes=%d", bytes)
+	resp, errGetRandomness := http.Get(url)
+	if errGetRandomness != nil {
+		return nil, errGetRandomness
+	}
+
+	body, errReadBody := ioutil.ReadAll(resp.Body)
+	if errReadBody != nil {
+		return nil, errReadBody
+	}
+
+	return body, nil
+
+	*/
+}

--- a/entropy/entropy.go
+++ b/entropy/entropy.go
@@ -6,13 +6,13 @@ import (
 
 // CustomRandomSource is a generic interface that any drand node operator can implement
 // to provide their own source of randomness in function GetRandom.
-type CustomRandomnSource interface {
+type EntropySource interface {
 	Read(data []byte) (n int, err error)
 }
 
 // GetRandom reads len bytes of randomness from whatever Reader is passed in, and returns
 // those bytes as the requested randomness.
-func GetRandom(source CustomRandomnSource, len uint32) ([]byte, error) {
+func GetRandom(source EntropySource, len uint32) ([]byte, error) {
 	if source == nil {
 		source = rand.Reader
 	}

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -5,25 +5,25 @@ import (
 	"testing"
 )
 
-func TestGetRandomness32Bytes(t *testing.T) {
-	random, err := GetRandom(32)
+func TestGetRandomness32BytesDefault(t *testing.T) {
+	random, err := GetRandom(nil,32)
 	if err != nil {
-		t.Fatal("Getting lavarand randomness failed:", err)
+		t.Fatal("Getting randomness failed:", err)
 	}
 	if len(random) != 32 {
 		t.Fatal("Randomness incorrect number of bytes:", len(random), "instead of 32")
 	}
 }
 
-func TestNoDuplicates(t *testing.T) {
-	random1, err := GetRandom(32)
+func TestNoDuplicatesDefault(t *testing.T) {
+	random1, err := GetRandom(nil, 32)
 	if err != nil {
-		t.Fatal("Getting lavarand randomness failed:", err)
+		t.Fatal("Getting randomness failed:", err)
 	}
 
-	random2, err := GetRandom(32)
+	random2, err := GetRandom(nil, 32)
 	if err != nil {
-		t.Fatal("Getting lavarand randomness failed:", err)
+		t.Fatal("Getting randomness failed:", err)
 	}
 	if bytes.Compare(random1, random2) == 0 {
 		t.Fatal("Randomness was the same for two samples, which is incorrect.")

--- a/entropy/entropy_test.go
+++ b/entropy/entropy_test.go
@@ -1,0 +1,31 @@
+package entropy
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestGetRandomness32Bytes(t *testing.T) {
+	random, err := GetRandom(32)
+	if err != nil {
+		t.Fatal("Getting lavarand randomness failed:", err)
+	}
+	if len(random) != 32 {
+		t.Fatal("Randomness incorrect number of bytes:", len(random), "instead of 32")
+	}
+}
+
+func TestNoDuplicates(t *testing.T) {
+	random1, err := GetRandom(32)
+	if err != nil {
+		t.Fatal("Getting lavarand randomness failed:", err)
+	}
+
+	random2, err := GetRandom(32)
+	if err != nil {
+		t.Fatal("Getting lavarand randomness failed:", err)
+	}
+	if bytes.Compare(random1, random2) == 0 {
+		t.Fatal("Randomness was the same for two samples, which is incorrect.")
+	}
+}


### PR DESCRIPTION
Hi! Thank you for your patience! This is a short and sweet PR that allows participants to feed their own source of randomness into their drand node. The logic defaults to crypto/rand if the custom randomness source fails for any reason.

Some questions I'd like feedback on:
1. Would you prefer that users pass in a `[n]byte` array into `GetRandom` instead of a length, and have the randomness written into that array? This would save us from heap allocations via `make()`.
2. Is this ergonomic enough?